### PR TITLE
Jad 6 projects view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,9 @@ import RequireNotAuth from "./components/auth/RequireNotAuth";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
 import MainPage from "./pages/MainPage";
+import ProjectProvider from "./components/projects/ProjectProvider";
+import ProjectsPage from "./pages/ProjectsPage";
+import ProjectPage from "./pages/ProjectPage";
 
 const router = createBrowserRouter(
   createRoutesFromElements([
@@ -18,7 +21,14 @@ const router = createBrowserRouter(
     </Route>,
 
     <Route element={<RequireAuth />}>
-      <Route path="/projects" element={<MainPage />}/>
+      <Route path="/projects" element={
+        <ProjectProvider>
+          <MainPage />
+        </ProjectProvider>
+      }>
+        <Route index element={<ProjectsPage />} />
+        <Route path=":projectId" element={<ProjectPage />} />
+      </Route>
     </Route>
   ])
 );

--- a/src/components/navbar/AppNavBar.tsx
+++ b/src/components/navbar/AppNavBar.tsx
@@ -16,8 +16,6 @@ export default function AppNavBar({disableLogout = false}: AppNavBarProps) {
   const {username, logout} = useAuth();
   const navigate = useNavigate();
 
-  console.log(username);
-
   const handleLogout = useCallback(() => {
     logout?.();
     navigate("/");

--- a/src/components/project-members/ProjectMemberProvider.tsx
+++ b/src/components/project-members/ProjectMemberProvider.tsx
@@ -1,0 +1,148 @@
+import {createContext, ReactNode, useCallback, useEffect, useState} from "react";
+import useAuth from "../../hooks/auth/useAuth";
+import {ProjectMember, projectService} from "../../services/ProjectService";
+import {ApiError} from "../../services/ApiError";
+
+type AddProjectMemberFn = (username: string, role: string) => Promise<ProjectMember>;
+type RemoveProjectMemberFn = (userId: number) => Promise<void>;
+
+interface ProjectMemberProviderState {
+  members?: ProjectMember[];
+  loading: boolean;
+  loadingError: ApiError | null;
+  addMember?: AddProjectMemberFn;
+  removeMember?: RemoveProjectMemberFn;
+  operating: boolean;
+  saveError: ApiError | null;
+  deleteError: ApiError | null;
+}
+
+const initialState: ProjectMemberProviderState = {
+  loading: false,
+  loadingError: null,
+  operating: false,
+  saveError: null,
+  deleteError: null,
+};
+
+export const ProjectMemberContext = createContext<ProjectMemberProviderState>(initialState);
+
+interface ProjectMemberProviderProps {
+  projectId: number;
+  children: ReactNode;
+}
+
+export default function ProjectMemberProvider({projectId, children}: ProjectMemberProviderProps) {
+  const [projectMembersState, setProjectMembersState] = useState<ProjectMemberProviderState>(initialState);
+  const {token} = useAuth();
+
+  useEffect(loadProjectMembersEffect, [projectId, token]);
+
+  const addMember: AddProjectMemberFn = useCallback(async (username, role) => {
+    setProjectMembersState({
+      ...projectMembersState,
+      operating: true,
+      saveError: null,
+    });
+
+    try {
+      const member = await projectService.addMemberToProject(projectId, username, role, token);
+
+      setProjectMembersState({
+        ...projectMembersState,
+        members: [...(projectMembersState.members ?? []), member],
+        operating: false,
+        saveError: null,
+      });
+
+      return member;
+    } catch (error) {
+      setProjectMembersState({
+        ...projectMembersState,
+        operating: false,
+        saveError: error as ApiError,
+      });
+
+      throw error as ApiError;
+    }
+  }, [projectMembersState, projectService, token, projectId]);
+
+  const removeMember: RemoveProjectMemberFn = useCallback(async (userId) => {
+    setProjectMembersState({
+      ...projectMembersState,
+      operating: true,
+      deleteError: null,
+    });
+
+    try {
+      await projectService.removeMemberFromProject(projectId, userId, token);
+
+      setProjectMembersState({
+        ...projectMembersState,
+        members: (projectMembersState.members ?? []).filter(m => m.userId !== userId),
+        operating: false,
+        deleteError: null,
+      });
+    } catch (error) {
+      setProjectMembersState({
+        ...projectMembersState,
+        operating: false,
+        deleteError: error as ApiError,
+      });
+
+      throw error as ApiError;
+    }
+  }, [projectMembersState, projectService, token, projectId]);
+
+  const {members, loading, loadingError, operating, saveError, deleteError} = projectMembersState;
+  const value = {
+    members, loading, loadingError,
+    addMember, removeMember, operating, saveError, deleteError
+  };
+  return (
+    <ProjectMemberContext.Provider value={value}>
+      {children}
+    </ProjectMemberContext.Provider>
+  );
+
+  function loadProjectMembersEffect() {
+    let canceled = false;
+
+    if (token.trim() !== '') {
+      loadProjectMembers();
+    }
+
+    return () => {
+      canceled = true;
+    };
+
+    async function loadProjectMembers() {
+      setProjectMembersState({
+        ...projectMembersState,
+        loading: true,
+        loadingError: null,
+      });
+
+      try {
+        const members = await projectService.getAllMembersForProject(projectId, token);
+
+        if (canceled) return;
+
+        setProjectMembersState({
+          ...projectMembersState,
+          members,
+          loading: false,
+          loadingError: null,
+        });
+      } catch (error) {
+        if (canceled) return;
+
+        setProjectMembersState({
+          ...projectMembersState,
+          loading: false,
+          loadingError: error as ApiError,
+        });
+      }
+    }
+  }
+}

--- a/src/components/project-members/ProjectMembersGroup.tsx
+++ b/src/components/project-members/ProjectMembersGroup.tsx
@@ -1,0 +1,72 @@
+import {ProjectMember} from "../../services/ProjectService";
+import {Avatar, AvatarGroup, Fab, Tooltip} from "@mui/material";
+import {avatarInitials, stringToColor} from "../../utils/AvatarUtils";
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
+
+interface ProjectMembersGroupProps {
+  lead: string;
+  members: ProjectMember[];
+  maxNumberOfMembers?: number;
+}
+
+export default function ProjectMembersGroup({lead, members, maxNumberOfMembers = 3}: ProjectMembersGroupProps) {
+  const maxAvatarCount = Math.min(maxNumberOfMembers + 1, members.length + 2);
+  const extraPlaceholderAvatars = Math.max(0, maxAvatarCount - members.length);
+
+  return (
+    <AvatarGroup
+      sx={{zIndex: 0}}
+      max={maxAvatarCount}
+      renderSurplus={(_) => (
+        <Tooltip title="Manage members">
+          <Fab
+            size="large"
+            sx={{
+              zIndex: 1,
+              ':hover': {
+                zIndex: 3
+              },
+            }}
+          >
+            <ManageAccountsIcon />
+          </Fab>
+        </Tooltip>
+      )}
+    >
+      <Tooltip title={`${lead} (Lead)`}>
+        <Avatar
+          sx={{
+            bgcolor: stringToColor(lead),
+            zIndex: 2,
+            ':hover': {
+              zIndex: 3
+            },
+          }}
+        >
+          {avatarInitials(lead)}
+        </Avatar>
+      </Tooltip>
+      {members.slice(0, maxAvatarCount).map(member => (
+        <Tooltip
+          key={member.userId}
+          title={`${member.username} (${member.role})`}
+        >
+          <Avatar
+            sx={{
+              bgcolor: stringToColor(member.username),
+              zIndex: 2,
+              ':hover': {
+                zIndex: 3
+              },
+            }}
+          >
+            {avatarInitials(member.username)}
+          </Avatar>
+        </Tooltip>
+      ))}
+      {Array.from({length: extraPlaceholderAvatars}).map((_, index) => (
+        <Avatar key={index} sx={{zIndex: 2}} />
+      ))}
+    </AvatarGroup>
+  )
+}

--- a/src/components/project-members/ProjectMembersView.tsx
+++ b/src/components/project-members/ProjectMembersView.tsx
@@ -1,0 +1,41 @@
+import {Project} from "../../services/ProjectService";
+import {CircularProgress, Stack} from "@mui/material";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import {useContext} from "react";
+import {ProjectMemberContext} from "./ProjectMemberProvider";
+import ProjectMembersGroup from "./ProjectMembersGroup";
+import ErrorSnackbar from "../core/ErrorSnackbar";
+
+interface ProjectMembersOverviewProps {
+  project?: Project;
+}
+
+export default function ProjectMembersView({project}: ProjectMembersOverviewProps) {
+  const {members, loading, loadingError} = useContext(ProjectMemberContext);
+
+  return (
+    <Box>
+      {project && (
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={2} sx={{alignItems: 'center'}}>
+            <Typography variant="h4">
+              {project.name}
+            </Typography>
+            {members !== undefined ? (
+              <ProjectMembersGroup lead={project.lead} members={members} />
+            ) : (loading && (
+              <CircularProgress />
+            ))}
+          </Stack>
+          <Typography variant="body1" sx={{pb: 1}}>
+            {project.description}
+          </Typography>
+        </Stack>
+      )}
+      {loadingError && (
+        <ErrorSnackbar error={loadingError} />
+      )}
+    </Box>
+  );
+}

--- a/src/components/projects/LoadingProjectsGrid.tsx
+++ b/src/components/projects/LoadingProjectsGrid.tsx
@@ -1,0 +1,36 @@
+import {Card, CardActions, CardContent, CardHeader, Skeleton} from "@mui/material";
+import Typography from "@mui/material/Typography";
+import Grid from "@mui/material/Grid2";
+
+interface LoadingProjectsGridProps {
+  numberOfProjects?: number;
+  editable?: boolean;
+}
+
+export default function LoadingProjectsGrid({numberOfProjects = 3, editable = false}: LoadingProjectsGridProps) {
+  return (
+    <Grid container spacing={2}>
+      {Array.from({length: numberOfProjects}).map((_, index) => (
+        <Grid size={4} key={index}>
+          <Card sx={{height: '100%'}}>
+            <CardHeader
+              title={<Skeleton />}
+              subheader={<Skeleton />}
+            />
+            <CardContent>
+              <Typography variant="body2" sx={{color: 'text.secondary'}}>
+                <Skeleton />
+              </Typography>
+            </CardContent>
+            {editable && (
+              <CardActions>
+                <Skeleton variant="rectangular" width={50} height={20} />
+                <Skeleton variant="rectangular" width={50} height={20} />
+              </CardActions>
+            )}
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,42 @@
+import {Project} from "../../services/ProjectService";
+import {Button, Card, CardActionArea, CardActions, CardContent, CardHeader} from "@mui/material";
+import Typography from "@mui/material/Typography";
+import {useNavigate} from "react-router-dom";
+
+interface ProjectCardProps {
+  project: Project;
+  editable?: boolean;
+  isOwner?: boolean;
+}
+
+export default function ProjectCard({project, editable = false, isOwner = false}: ProjectCardProps) {
+  const navigate = useNavigate();
+
+  const handleCardClick = () => {
+    navigate(`/projects/${project.id}`);
+  };
+
+  return (
+    <Card sx={{':hover': {
+        boxShadow: 6, // theme.shadows[20]
+      },}}>
+      <CardActionArea onClick={handleCardClick}>
+        <CardHeader
+          title={project.name}
+          subheader={`Lead: ${isOwner ? 'You' : project.lead}`}
+        />
+        <CardContent>
+          <Typography variant="body2" sx={{color: 'text.secondary'}}>
+            {project.description}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+      {editable && (
+        <CardActions>
+          <Button size="small">Edit</Button>
+          <Button size="small">Delete</Button>
+        </CardActions>
+      )}
+    </Card>
+  );
+}

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -17,9 +17,12 @@ export default function ProjectCard({project, editable = false, isOwner = false}
   };
 
   return (
-    <Card sx={{':hover': {
-        boxShadow: 6, // theme.shadows[20]
-      },}}>
+    <Card sx={{
+        ':hover': {
+          boxShadow: 6,
+        },
+      }}
+    >
       <CardActionArea onClick={handleCardClick}>
         <CardHeader
           title={project.name}

--- a/src/components/projects/ProjectProvider.tsx
+++ b/src/components/projects/ProjectProvider.tsx
@@ -1,0 +1,181 @@
+import {createContext, ReactNode, useCallback, useEffect, useState} from "react";
+import {Project, projectService} from "../../services/ProjectService";
+import {ApiError} from "../../services/ApiError";
+import useAuth from "../../hooks/auth/useAuth";
+
+type CreateProjectFn = (name: string, description: string) => Promise<Project>;
+type RenameProjectFn = (projectId: number, name: string) => Promise<Project>;
+type DeleteProjectFn = (projectId: number) => Promise<void>;
+
+interface ProjectProviderState {
+  projects?: Project[];
+  loading: boolean;
+  loadingError: ApiError | null;
+  createProject?: CreateProjectFn;
+  renameProject?: RenameProjectFn;
+  deleteProject?: DeleteProjectFn;
+  operating: boolean;
+  saveError: ApiError | null;
+  renameError: ApiError | null;
+  deleteError: ApiError | null;
+}
+
+const initialState: ProjectProviderState = {
+  loading: false,
+  loadingError: null,
+  operating: false,
+  saveError: null,
+  renameError: null,
+  deleteError: null,
+};
+
+export const ProjectContext = createContext<ProjectProviderState>(initialState);
+
+interface ProjectProviderProps {
+  children: ReactNode;
+}
+
+export default function ProjectProvider({children}: ProjectProviderProps) {
+  const [projectsState, setProjectsState] = useState<ProjectProviderState>(initialState);
+  const {token} = useAuth();
+
+  useEffect(loadProjectsEffect, [token]);
+
+  const createProject: CreateProjectFn = useCallback(async (name, description) => {
+    setProjectsState({
+      ...projectsState,
+      operating: true,
+      saveError: null,
+    });
+
+    try {
+      const project = await projectService.createProject(name, description, token);
+
+      setProjectsState({
+        ...projectsState,
+        projects: [...(projectsState.projects ?? []), project],
+        operating: false,
+        saveError: null,
+      });
+
+      return project;
+    } catch (error) {
+      setProjectsState({
+        ...projectsState,
+        operating: false,
+        saveError: error as ApiError,
+      });
+
+      throw error as ApiError;
+    }
+  }, [projectsState, projectService, token]);
+
+  const renameProject: RenameProjectFn = useCallback(async (projectId, name) => {
+    setProjectsState({
+      ...projectsState,
+      operating: true,
+      renameError: null,
+    });
+
+    try {
+      const project = await projectService.renameProject(projectId, name, token);
+
+      setProjectsState({
+        ...projectsState,
+        projects: (projectsState.projects ?? []).map(p => p.id === projectId ? project : p),
+        operating: false,
+        renameError: null,
+      });
+
+      return project;
+    } catch (error) {
+      setProjectsState({
+        ...projectsState,
+        operating: false,
+        renameError: error as ApiError,
+      });
+
+      throw error as ApiError;
+    }
+  }, [projectsState, projectService, token]);
+
+  const deleteProject: DeleteProjectFn = useCallback(async (projectId) => {
+    setProjectsState({
+      ...projectsState,
+      operating: true,
+      deleteError: null,
+    });
+
+    try {
+      await projectService.deleteProject(projectId, token);
+
+      setProjectsState({
+        ...projectsState,
+        projects: (projectsState.projects ?? []).filter(p => p.id !== projectId),
+        operating: false,
+        deleteError: null,
+      });
+    } catch (error) {
+      setProjectsState({
+        ...projectsState,
+        operating: false,
+        deleteError: error as ApiError,
+      });
+
+      throw error as ApiError;
+    }
+  }, [projectsState, projectService, token]);
+
+  const {projects, loading, loadingError, operating, saveError, renameError, deleteError} = projectsState;
+  const value = {
+    projects, loading, loadingError,
+    createProject, renameProject, deleteProject, operating, saveError, renameError, deleteError
+  };
+
+  return (
+    <ProjectContext.Provider value={value}>
+      {children}
+    </ProjectContext.Provider>
+  );
+
+  function loadProjectsEffect() {
+    let canceled = false;
+
+    if (token.trim() != '') {
+      loadProjects();
+    }
+
+    return () => {
+      canceled = true;
+    };
+
+    async function loadProjects() {
+      setProjectsState({
+        ...projectsState,
+        loading: true,
+        loadingError: null,
+      });
+
+      try {
+        const projects = await projectService.getAll(token);
+
+        if (canceled) return;
+
+        setProjectsState({
+          ...projectsState,
+          projects,
+          loading: false,
+          loadingError: null,
+        });
+      } catch (error) {
+        if (canceled) return;
+
+        setProjectsState({
+          ...projectsState,
+          loading: false,
+          loadingError: error as ApiError,
+        });
+      }
+    }
+  }
+}

--- a/src/components/projects/ProjectsGrid.tsx
+++ b/src/components/projects/ProjectsGrid.tsx
@@ -1,0 +1,21 @@
+import {Project} from "../../services/ProjectService";
+import Grid from "@mui/material/Grid2";
+import ProjectCard from "./ProjectCard";
+
+interface ProjectsGridProps {
+  projects: Project[];
+  editable?: boolean;
+  isOwner?: boolean;
+}
+
+export default function ProjectsGrid({projects, editable = false, isOwner = false}: ProjectsGridProps) {
+  return (
+    <Grid container spacing={2}>
+      {projects.map(project => (
+        <Grid size={4} key={project.id}>
+          <ProjectCard project={project} editable={editable} isOwner={isOwner} />
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -9,7 +9,6 @@ export default function MainPage() {
       <AppNavBar />
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />
-        <h1>Main Page</h1>
         <Outlet />
       </Box>
     </Box>

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -1,0 +1,15 @@
+import {useParams} from "react-router-dom";
+import ProjectMemberProvider from "../components/project-members/ProjectMemberProvider";
+
+export default function ProjectPage() {
+  const {projectId} = useParams();
+  const parsedProjectId = parseInt(projectId ?? '0', 10);
+
+  return (
+    <ProjectMemberProvider projectId={parsedProjectId}>
+      <div>
+        <h1>Project</h1>
+      </div>
+    </ProjectMemberProvider>
+  );
+}

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -1,15 +1,24 @@
 import {useParams} from "react-router-dom";
 import ProjectMemberProvider from "../components/project-members/ProjectMemberProvider";
+import Box from "@mui/material/Box";
+import ProjectMembersView from "../components/project-members/ProjectMembersView";
+import {useContext} from "react";
+import {ProjectContext} from "../components/projects/ProjectProvider";
 
 export default function ProjectPage() {
   const {projectId} = useParams();
+  const {projects} = useContext(ProjectContext);
+
   const parsedProjectId = parseInt(projectId ?? '0', 10);
+  const project = projects?.find(project => project.id === parsedProjectId);
 
   return (
     <ProjectMemberProvider projectId={parsedProjectId}>
-      <div>
-        <h1>Project</h1>
-      </div>
+      <Box sx={{display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
+        <Box sx={{width: '85%'}}>
+          <ProjectMembersView project={project} />
+        </Box>
+      </Box>
     </ProjectMemberProvider>
   );
 }

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,0 +1,77 @@
+import {useContext} from "react";
+import {ProjectContext} from "../components/projects/ProjectProvider";
+import ProjectsGrid from "../components/projects/ProjectsGrid";
+import {Button, Divider} from "@mui/material";
+import Grid from "@mui/material/Grid2";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import useAuth from "../hooks/auth/useAuth";
+import ErrorSnackbar from "../components/core/ErrorSnackbar";
+import LoadingProjectsGrid from "../components/projects/LoadingProjectsGrid";
+
+export default function ProjectsPage() {
+  const {projects, loading, loadingError} = useContext(ProjectContext);
+  const {username} = useAuth();
+
+  const ownedProjects = projects?.filter(project => project.lead === username)
+  const otherProjects = projects?.filter(project => project.lead !== username)
+
+  return (
+    <Box sx={{display: 'flex', justifyContent: 'center', alignItems: 'center', width: '100%'}}>
+      <Grid container spacing={2} sx={{width: '85%'}}>
+        <Grid size={6}>
+          <Box sx={{p: 2}}>
+            <Box sx={{display: 'flex', alignItems: 'center', pb: 1}}>
+              <Typography variant="h5" gutterBottom sx={{flexGrow: 1}}>
+                Your projects
+              </Typography>
+              <Button>
+                Create new project
+              </Button>
+            </Box>
+            <Divider sx={{mb: 2}}/>
+            {ownedProjects && ownedProjects.length > 0 ? (
+              <ProjectsGrid projects={ownedProjects} editable isOwner />
+            ) : (
+              <Box>
+                {loading ? (
+                  <LoadingProjectsGrid editable />
+                ) : (
+                  <Typography sx={{p: 1}} variant="body2">
+                    No projects found
+                  </Typography>
+                )}
+              </Box>
+            )}
+          </Box>
+        </Grid>
+        <Grid size={6}>
+          <Box sx={{p: 2}}>
+            <Box sx={{pb: 1}}>
+              <Typography variant="h5" gutterBottom>
+                Other projects
+              </Typography>
+            </Box>
+            <Divider sx={{mb: 2}}/>
+            {otherProjects && otherProjects.length > 0 ? (
+              <ProjectsGrid projects={otherProjects} />
+            ) : (
+              <Box>
+                {loading ? (
+                  <LoadingProjectsGrid />
+                ) : (
+                  <Typography sx={{p: 1}} variant="body2">
+                    No projects found
+                  </Typography>
+                )}
+              </Box>
+            )}
+          </Box>
+        </Grid>
+      </Grid>
+      {loadingError && (
+        <ErrorSnackbar error={loadingError} />
+      )}
+    </Box>
+  );
+}

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -1,0 +1,148 @@
+import {apiClient,} from "./ApiClient";
+import {convertError} from "./ApiError";
+import {AxiosError} from "axios";
+
+export interface Project {
+  id: number;
+  name: string;
+  description: string;
+  lead: string;
+}
+
+export interface ProjectMember {
+  userId: number;
+  username: string;
+  role: string;
+}
+
+class ProjectService {
+  private endpoint = "/projects";
+
+  public async getAll(token: string): Promise<Project[]> {
+    try {
+      const response = await apiClient.get(
+        this.endpoint,
+        {
+          headers: {
+            "Authorization": `Bearer ${token}`,
+          },
+        }
+      );
+
+      return response.data;
+    } catch (error) {
+      throw convertError(error as AxiosError | Error);
+    }
+  }
+
+  public async createProject(name: string, description: string, token: string): Promise<Project> {
+    try {
+      const response = await apiClient.post(
+        this.endpoint,
+        {
+          name,
+          description,
+        },
+        {
+          headers: {
+            "Authorization": `Bearer ${token}`,
+          },
+        }
+      );
+
+      return response.data;
+    } catch (error) {
+      throw convertError(error as AxiosError | Error);
+    }
+  }
+
+  public async renameProject(projectId: number, name: string, token: string): Promise<Project> {
+    try {
+      const response = await apiClient.put(
+        `${this.endpoint}/${projectId}`,
+        {
+          name,
+        },
+        {
+          headers: {
+            "Authorization": `Bearer ${token}`,
+          },
+        }
+      );
+
+      return response.data;
+    } catch (error) {
+      throw convertError(error as AxiosError | Error);
+    }
+  }
+
+  public async deleteProject(projectId: number, token: string): Promise<void> {
+    try {
+      await apiClient.delete(
+        `${this.endpoint}/${projectId}`,
+        {
+          headers: {
+            "Authorization": `Bearer ${token}`,
+          },
+        }
+      );
+    } catch (error) {
+      throw convertError(error as AxiosError | Error);
+    }
+  }
+
+  public async getAllMembersForProject(projectId: number, token: string): Promise<ProjectMember[]> {
+    try {
+      const response = await apiClient.get(
+        `${this.endpoint}/${projectId}/members`,
+        {
+          headers: {
+            "Authorization": `Bearer ${token}`,
+          },
+        }
+      );
+
+      return response.data;
+    } catch (error) {
+      throw convertError(error as AxiosError | Error);
+    }
+  }
+
+  public async addMemberToProject(projectId: number, username: string, role: string, token: string): Promise<ProjectMember> {
+    try {
+      const response = await apiClient.post(
+        `${this.endpoint}/${projectId}/members`,
+        {
+          username,
+          role,
+        },
+        {
+          headers: {
+            "Authorization": `Bearer ${token}`,
+          },
+        }
+      );
+
+      return response.data;
+    } catch (error) {
+      throw convertError(error as AxiosError | Error);
+    }
+  }
+
+  public async removeMemberFromProject(projectId: number, userId: number, token: string): Promise<void> {
+    try {
+      await apiClient.delete(
+        `${this.endpoint}/${projectId}/members/${userId}`,
+        {
+          headers: {
+            "Authorization": `Bearer ${token}`,
+          },
+        }
+      );
+    } catch (error) {
+      throw convertError(error as AxiosError | Error);
+    }
+  }
+}
+
+export const projectService = new ProjectService();


### PR DESCRIPTION
Only the view/read-only aspects for:
- Projects page
- Project details page (overview component for the members and project)
- Loading and error handling

Remain to be implemented:
- Dialog for new project
- Dialog for renaming a project
- Dialog for viewing the complete list of members (+ operations on that list)
- Linking all the buttons on the projects and project details pages.